### PR TITLE
Fixed invalid header field name :authority error

### DIFF
--- a/static/proxy/template/layout/pkg/wiremock/client.go
+++ b/static/proxy/template/layout/pkg/wiremock/client.go
@@ -82,8 +82,9 @@ func doRequest(request *http.Request) (*http.Response, error) {
 			if len(mdValue) > 0 {
 				if mdKey == ":authority" {
 					request.Host = mdValue[0]
+				} else {
+					request.Header.Set(mdKey, mdValue[0])
 				}
-				request.Header.Set(mdKey, mdValue[0])
 			}
 		}
 	}


### PR DESCRIPTION
Now since :authority header is passed to http request we got the following message while trying to send GRPC request:
` invalid header field name ":authority"`
Fixed the error
![image](https://github.com/SberMarket-Tech/grpc-wiremock/assets/78476307/9770ca0e-226b-4d33-93da-3842f52d56f3)
